### PR TITLE
Adding updated Node and BitGrid with reduced size and no dynamic memo…

### DIFF
--- a/include/bitgrid.hpp
+++ b/include/bitgrid.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+template<std::size_t W, std::size_t H>
+class BitGrid
+{
+    std::array<uint8_t, (W * H + 7)/8> grid;
+public:
+    bool get(int x, int y);
+    void set(int x, int y, bool val);
+    constexpr size_t width() const { return W; }
+    constexpr size_t height() const { return H; }
+};
+
+template<std::size_t W, std::size_t H>
+bool BitGrid<W, H>::get(int x, int y)
+{
+    int index = y*W+x;
+    int byte_num = index / 8;
+    int bit_offset = index % 8;
+    return (this->grid[byte_num] >> bit_offset ) & 1;
+}
+
+template<std::size_t W, std::size_t H>
+void BitGrid<W, H>::set(int x, int y, bool val)
+{
+    int index = y*W+x;
+    int byte_num = index / 8;
+    int bit_offset = index % 8;
+    if(val)
+        this->grid[byte_num] |= (1 << bit_offset);
+    else
+        this->grid[byte_num] &= ~(1 << bit_offset);
+}
+

--- a/include/node.hpp
+++ b/include/node.hpp
@@ -3,14 +3,17 @@
 #include <vector>
 #include <array> 
 #include <limits>
+#include <cstdint>
 
 struct Node
 {
-    int node_id;
-    int backpointer = -1;
-    int d_exit = std::numeric_limits<int>::max();
-    int safety = std::numeric_limits<int>::max();
-    double cost = 0.0;
+    std::int16_t node_id;
+    std::int16_t backpointer = -1;
+    std::int16_t d_exit = std::numeric_limits<std::int16_t>::max();
+    std::int16_t safety = std::numeric_limits<std::int16_t>::max();
+    float cost = 0.0;
+    // X, Y coordinates of Node
     std::array<int, 2> coords {};
-    std::vector<int> neighbors;
+    // Node Id of 4 N/E/S/W neigbors.    
+    std::array<int16_t, 4> neighbors; 
 };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,3 @@
-# test/CMakeLists.txt
-
 include(FetchContent)
 
 FetchContent_Declare(
@@ -9,10 +7,16 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(Catch2)
 
+include(Catch)  # <-- must be here, after FetchContent_MakeAvailable
+
+# Node tests
 add_executable(test_node test_node.cpp)
 target_include_directories(test_node PRIVATE ../include)
 target_link_libraries(test_node PRIVATE Catch2::Catch2WithMain)
-
-include(CTest)
-include(Catch)
 catch_discover_tests(test_node)
+
+# BitGrid tests
+add_executable(test_bitgrid test_bitgrid.cpp)
+target_include_directories(test_bitgrid PRIVATE ../include)
+target_link_libraries(test_bitgrid PRIVATE Catch2::Catch2WithMain)
+catch_discover_tests(test_bitgrid)

--- a/test/test_bitgrid.cpp
+++ b/test/test_bitgrid.cpp
@@ -1,0 +1,45 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch_test_macros.hpp>
+#include "../include/bitgrid.hpp"
+
+TEST_CASE("BitGrid basic functionality", "[BitGrid]") {
+    constexpr std::size_t W = 8;
+    constexpr std::size_t H = 8;
+    BitGrid<W, H> grid;
+
+    SECTION("Initial state is all false") {
+        for (std::size_t y = 0; y < H; ++y) {
+            for (std::size_t x = 0; x < W; ++x) {
+                REQUIRE(grid.get(x, y) == false);
+            }
+        }
+    }
+
+    SECTION("Set and get work correctly") {
+        grid.set(3, 2, true);
+        REQUIRE(grid.get(3, 2) == true);
+
+        grid.set(3, 2, false);
+        REQUIRE(grid.get(3, 2) == false);
+
+        grid.set(0, 0, true);
+        grid.set(7, 7, true);
+        REQUIRE(grid.get(0, 0) == true);
+        REQUIRE(grid.get(7, 7) == true);
+    }
+
+    SECTION("Does not affect neighboring bits") {
+        grid.set(4, 4, true);
+        for (std::size_t y = 0; y < H; ++y) {
+            for (std::size_t x = 0; x < W; ++x) {
+                if (x == 4 && y == 4) continue;
+                REQUIRE(grid.get(x, y) == false);
+            }
+        }
+    }
+
+    SECTION("width() and height() return correct values") {
+        REQUIRE(grid.width() == W);
+        REQUIRE(grid.height() == H);
+    }
+}

--- a/test/test_node.cpp
+++ b/test/test_node.cpp
@@ -10,25 +10,25 @@ TEST_CASE("Node initializes with correct default values", "[Node]") {
 
     SECTION("Default-initialized fields") {
         REQUIRE(n.backpointer == -1);
-        REQUIRE(n.d_exit == std::numeric_limits<int>::max());
-        REQUIRE(n.safety == std::numeric_limits<int>::max());
-        REQUIRE(n.cost == 0.0);
+        REQUIRE(n.d_exit == std::numeric_limits<std::int16_t>::max());
+        REQUIRE(n.safety == std::numeric_limits<std::int16_t>::max());
+        REQUIRE(n.cost == 0.0f);
         REQUIRE(n.coords[0] == 0);
         REQUIRE(n.coords[1] == 0);
-        REQUIRE(n.neighbors.empty());
+        REQUIRE(n.neighbors == std::array<int16_t, 4>{}); // All zeros
     }
 
     SECTION("Node can be assigned values") {
         n.node_id = 5;
         n.coords = {3, 4};
-        n.cost = 12.5;
-        n.neighbors = {1, 2, 3};
+        n.cost = 12.5f;
+        n.neighbors = {1, 2, 3, 4}; // Must fill all 4
 
         REQUIRE(n.node_id == 5);
         REQUIRE(n.coords[0] == 3);
         REQUIRE(n.coords[1] == 4);
-        REQUIRE(n.cost == Catch::Approx(12.5));
-        REQUIRE(n.neighbors.size() == 3);
+        REQUIRE(n.cost == Catch::Approx(12.5f));
+        REQUIRE(n.neighbors.size() == 4);
         REQUIRE(n.neighbors[2] == 3);
     }
 }


### PR DESCRIPTION
…ry allocation to save heap space.

Instead BitGrid is a packed bitmap representing the 2D grid as a 1D array with each 'true' bit representing whether the corresponding cell in the graph has an obstacle. Similarly Node was restructured to have statically allocated memory, and smaller data types to reduce the overall memory footprint of each node.